### PR TITLE
Fix GHCR image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Build app
       run: CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-X 'main.version=${{ steps.version.outputs.full }}'" -o bin/${{ env.APP_NAME }} .
-    
+
     - name: Generate MD5
       run: md5sum bin/${{ env.APP_NAME }} > bin/${{ env.APP_NAME }}.md5
 
@@ -60,9 +60,9 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
+          type=semver,pattern={{raw}}
+          type=semver,pattern=v{{major}}.{{minor}}
+          type=semver,pattern=v{{major}}
           type=sha
 
     - name: Log in to GitHub Container Registry


### PR DESCRIPTION
Hi there, I found a bug when try to install this package using the helm chart and I would like to suggest the fix for this.

The error is `ErrImagePull` and this bug start when this repo migrate from dockerhub to ghcr. This happens because the helm chart try to download the image `ghcr.io/labbs/github-actions-exporter:v1.9.0` ([here](https://github.com/Labbs/helm-charts/blob/main/charts/github-actions-exporter/values.yaml#L6)), but this image tag doesn't exists on ghcr. 

All image tags on ghcr was generated without the prefix `v` and my suggestion is put this prefix to mantain the same pattern that was used in the dockerhub.

So I did this fix using the [docker metadata docs](https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver) and below have the comparasion tags:
- **before**: `latest, sha-5e37462, 1, 1.9, 1.9.0`
- **result**: `latest, sha-5e37462, v1, v1.9, v1.9.0`