### PR TITLE
add cancelled metric for workflow status gauge

### DIFF
--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -120,6 +120,8 @@ func getWorkflowRunsFromGithub() {
 					s = 3
 				} else if run.GetConclusion() == "queued" {
 					s = 4
+				} else if run.GetConclusion() == "cancelled" {
+					s = 5
 				}
 
 				fields := getRelevantFields(repo, run)


### PR DESCRIPTION
Add new metric for cancelled workflow runs to the same workflowRunStatusGauge counter